### PR TITLE
feat: fetch once on first load outside commute window (no auto-refresh)

### DIFF
--- a/app.js
+++ b/app.js
@@ -166,4 +166,6 @@ function stopAuto() { if (timer) { clearInterval(timer); timer = null; } }
 
 els.auto.addEventListener("change", () => els.auto.checked ? startAuto() : stopAuto());
 els.reload.addEventListener("click", loadOnce);
+// New behavior: fetch once on first load even if outside commute window
+if (!withinCommuteWindow()) { loadOnce(); }
 startAuto();


### PR DESCRIPTION
Show current departures on first load even when outside 17:30–19:00.
Auto-refresh remains active only during the commute window.
No changes to time parsing or manifest.