### PR TITLE
Normalize American spelling in CSS comment

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -85,7 +85,7 @@ main { padding: 1rem; max-width: 900px; margin-inline:auto; }
 .card { border:1px solid var(--line); background:var(--card); border-radius:12px; padding:1rem; }
 .card h2 { margin:.25rem 0 1rem; font-size:1rem; }
 
-/* Status banner (colour-coded) */
+/* Status banner (color-coded) */
 .status {
   padding: .75rem 1rem; 
   border-radius:10px; 


### PR DESCRIPTION
## Summary
- use "color" spelling in status banner comment to match American English elsewhere in project

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689dfb88132c832eb3f249b48f24f0ee