### PR TITLE
Remove fixed line/station info from footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,8 +48,7 @@
     <section class="card">
       <footer>
         <div>
-          <span>Fixed to <code>line=DRL</code>, <code>station=DIS</code>, <code>lang=EN</code></span>
-          • Auto refresh ~25s within window.
+          Auto refresh ~25s within window.
         </div>
         <div>
           Data © MTR Corporation via DATA.GOV.HK.<br />


### PR DESCRIPTION
## Summary
- trim footer text to remove fixed line/station/language details, leaving only auto refresh info

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_689dfea35180832eafe5794bea2885d3