### PR TITLE
chore: update API spec link to v1.7

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
         </div>
         <div>
           Data © MTR Corporation via DATA.GOV.HK.<br />
-          (<a href="https://opendata.mtr.com.hk/doc/Next_Train_API_Spec_v1.6.pdf" target="_blank" rel="noopener noreferrer">API Spec</a> ·
+          (<a href="https://opendata.mtr.com.hk/doc/Next_Train_API_Spec_v1.7.pdf" target="_blank" rel="noopener noreferrer">API Spec</a> ·
           <a href="https://opendata.mtr.com.hk/doc/Next_Train_DataDictionary_v1.7.pdf" target="_blank" rel="noopener noreferrer">Data Dictionary</a>)
         </div>
       </footer>


### PR DESCRIPTION
## Summary
- reference latest Next Train API spec (v1.7) in footer

## Testing
- `npm test` *(fails: ENOENT, could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689e008d807c832ebaca3869384082ff