### PR TITLE
fix: ensure ETA display uses robust date parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -89,7 +89,7 @@ function renderUP(trains, now) {
   }
   trains.slice(0, 4).forEach((t) => {
     const etaMin  = minutesDiff(now, parseHKTime(t.time));
-    const timeStr = new Date(t.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    const timeStr = parseHKTime(t.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
     const li = document.createElement("li");
     li.className = "train";
     li.innerHTML = `
@@ -174,7 +174,7 @@ startAuto();
 // --- TCL Line: Sunny Bay departures towards Hong Kong Station ---
 async function fetchTCLSchedule() {
   const url = 'https://rt.data.gov.hk/v1/transport/mtr/getSchedule.php?line=TCL&sta=SUN&lang=EN';
-  const res = await fetch(url);
+  const res = await fetch(url, { mode: "cors" });
   if (!res.ok) throw new Error(`TCL HTTP ${res.status}`);
   return res.json();
 }
@@ -188,7 +188,7 @@ async function loadTCL() {
     list.innerHTML = '';
     (section.UP || []).slice(0, 4).forEach((t) => {
       const etaMin = minutesDiff(now, parseHKTime(t.time));
-      const timeStr = new Date(t.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const timeStr = parseHKTime(t.time).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
       const li = document.createElement('li');
       li.className = 'train';
       li.innerHTML = `

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "mtr-train-dashboard",
+  "version": "1.0.0",
+  "description": "MTR train dashboard",
+  "scripts": {
+    "test": "node --check app.js"
+  }
+}


### PR DESCRIPTION
## Summary
- use `parseHKTime` when formatting ETAs to avoid unreliable `Date` parsing
- request TCL schedule with explicit CORS mode
- add package.json with test script so `npm test` runs a syntax check

## Testing
- `node --check app.js`
- `npm test` *(warns about unknown env config "http-proxy")*

------
https://chatgpt.com/codex/tasks/task_e_689e0641d730832eb97e40161bef5e0b